### PR TITLE
removing SNAPSHOT from beam maven reference

### DIFF
--- a/education.ml/pipeline/myapps/beam/tutorial/pom.xml
+++ b/education.ml/pipeline/myapps/beam/tutorial/pom.xml
@@ -9,7 +9,7 @@
 
 
   <properties>
-    <beam.version>0.3.0-incubating-SNAPSHOT</beam.version>
+    <beam.version>0.3.0-incubating</beam.version>
     <slf4j.version>1.7.5</slf4j.version>
     <junit.version>4.8.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
Beam 0.4.0 was released on 12/29/2016 which is no longer incubating.  I tried using the 0.4.0 release but it breaks the build due to org.apache.beam.sdk.values.PCollection (apply method) & org.apache.beam.sdk.transforms.PTransform (new expand method) signature changes.
 
Changing beam.version property from 0.3.0-incubating-SNAPSHOT to 0.3.0-incubating to resolve the following error:
[ERROR] Failed to execute goal on project tutorial: Could not resolve dependencies for project com.advancedspark:tutorial:jar:0.0.1-SNAPSHOT: The following artifacts could not be resolved: 
org.apache.beam:beam-sdks-java-core:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-runners-direct-java:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-sdks-java-io-google-cloud-platform:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-runners-spark:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-runners-flink_2.10:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-runners-google-cloud-dataflow-java:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-examples-java8:jar:0.3.0-incubating-SNAPSHOT, 
org.apache.beam:beam-examples-java:jar:0.3.0-incubating-SNAPSHOT
Failure to find org.apache.beam:beam-sdks-java-core:jar:0.3.0-incubating-SNAPSHOT